### PR TITLE
Fix broken build, use proc_macro2 properly

### DIFF
--- a/caller_modpath/src/lib.rs
+++ b/caller_modpath/src/lib.rs
@@ -188,9 +188,7 @@ fn resolve_modpath(client_proc_macro_crate_name: &str) -> String {
     let liblink_path = format!("{}={}", client_proc_macro_crate_name, chosen_dir);
 
     let rustc_args = vec![
-        "-Z",
-        "unstable-options",
-        "--pretty=expanded",
+        "-Zunpretty=expanded",
         "--color=never",
         "--extern",
         &liblink_path,

--- a/caller_modpath/src/lib.rs
+++ b/caller_modpath/src/lib.rs
@@ -88,7 +88,7 @@ pub trait CallerModpath {
     fn caller_modpath() -> String;
 }
 
-impl CallerModpath for proc_macro::Span {
+impl CallerModpath for proc_macro2::Span {
     fn caller_modpath() -> String {
         let call_site = proc_macro2::Span::call_site().unwrap();
         // First, try to find any mention of it (it's initialized by the macro)
@@ -128,12 +128,9 @@ impl CallerModpath for proc_macro::Span {
     }
 }
 
-// I just want this available for both types
-/// This impl is for [`proc_macro2::Span`](https://docs.rs/proc-macro2/1.0.24/proc_macro2/struct.Span.html).
-/// The backend is the exact same; this is just provided for convienience.
-impl CallerModpath for proc_macro2::Span {
+impl CallerModpath for proc_macro::Span {
     fn caller_modpath() -> String {
-        proc_macro::Span::caller_modpath()
+        proc_macro2::Span::caller_modpath()
     }
 }
 


### PR DESCRIPTION
See also: https://github.com/dtolnay/cargo-expand/pull/114/files
Closes #2 

This PR gets this crate working on the current version of `rustc`.

In addition, the impl on `proc_macro2::Span` calls the `proc_macro::Span`, but `proc_macro` is not available in non-proc-macro contexts, such as unit tests. Since the business logic already used `proc_macro2`, I simply switched the impls.