### PR TITLE
Switch from pretty to unpretty to work on latest nightly

### DIFF
--- a/caller_modpath/src/lib.rs
+++ b/caller_modpath/src/lib.rs
@@ -188,9 +188,7 @@ fn resolve_modpath(client_proc_macro_crate_name: &str) -> String {
     let liblink_path = format!("{}={}", client_proc_macro_crate_name, chosen_dir);
 
     let rustc_args = vec![
-        "-Z",
-        "unstable-options",
-        "--pretty=expanded",
+        "-Zunpretty=expanded",
         "--color=never",
         "--extern",
         &liblink_path,


### PR DESCRIPTION
See also: https://github.com/dtolnay/cargo-expand/pull/114/files
Closes https://github.com/Shizcow/caller_modpath/issues/2

This PR gets this crate working on the current version of `rustc`.